### PR TITLE
elasticsearch v5 changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ naxsi:
 
 elasticsearch:
   image: elasticsearch:latest
-  command: elasticsearch -Des.network.host=0.0.0.0
+  command: elasticsearch -Enetwork.host=0.0.0.0
 # Uncomment to allow access from network
 #  ports:
 #    - "9200:9200"


### PR DESCRIPTION
elasticsearch in v5 changed args, since this docker-compose.yml uses elasticsearch:**latest** it needs to update used args